### PR TITLE
feat(codecs): use TextEncoder if available for performance

### DIFF
--- a/lib/codecs.js
+++ b/lib/codecs.js
@@ -3,8 +3,18 @@
 var inflateRawSync = require("zlib").inflateRawSync;
 var deflateRawSync = require("zlib").deflateRawSync;
 
+/** @type { TextEncoder } */
+var textEncoder;
+if (global.TextEncoder) {
+    textEncoder = new TextEncoder();
+}
+
 function jsonEncoder(data) {
-    return Buffer.from(JSON.stringify(data));
+    var stringData = JSON.stringify(data);
+    if (textEncoder) {
+        return Buffer.from(textEncoder.encode(stringData));
+    }
+    return Buffer.from(stringData);
 }
 
 function jsonDecoder(data) {


### PR DESCRIPTION
Use TextEncoder, if available, to improve JSON encoding

TextEncoder.encode(string) returns an Uint8Array natively, so Buffer.from does not need to handle utf-8 itself